### PR TITLE
Puppet 6 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,7 @@
 fixtures:
   repositories:
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib
+  forge_modules:
+    cron_core: puppetlabs/cron_core
   symlinks:
     cron: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ jobs:
     - env:
       - DO=validate_all
       - PUPPET='~> 5'
+    - env:
+        - DO=validate_all
+        - PUPPET='~> 6'
     - stage: unit
       env:
       - DO=spec
@@ -26,6 +29,9 @@ jobs:
     - env:
       - DO=spec
       - PUPPET='~> 5'
+    - env:
+        - DO=spec
+        - PUPPET='~> 6'
     - stage: acceptance
       env:
       - DO=beaker

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       - BEAKER_set=ubuntu_1604
     - env:
       - DO=beaker
-      - PUPPET='~> 6'
+      - PUPPET='~> 5'
       - BEAKER_set=ubuntu_1804
     - stage: deploy
       script: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       - BEAKER_set=ubuntu_1604
     - env:
       - DO=beaker
-      - PUPPET='~> 5'
+      - PUPPET='~> 6'
       - BEAKER_set=ubuntu_1804
     - stage: deploy
       script: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,24 +35,29 @@ jobs:
     - stage: acceptance
       env:
       - DO=beaker
-      - BEAKER_PUPPET_COLLECTION=puppet5
       - BEAKER_set=ubuntu_1404
-    - env:
-      - DO=beaker
       - BEAKER_PUPPET_COLLECTION=puppet5
-      - BEAKER_set=ubuntu_1604
+      - BEAKER_debug=true
     - env:
       - DO=beaker
-      - BEAKER_PUPPET_COLLECTION=puppet6
       - BEAKER_set=ubuntu_1604
-    - env:
-      - DO=beaker
       - BEAKER_PUPPET_COLLECTION=puppet5
-      - BEAKER_set=ubuntu_1804
+      - BEAKER_debug=true
     - env:
       - DO=beaker
+      - BEAKER_set=ubuntu_1604
       - BEAKER_PUPPET_COLLECTION=puppet6
+      - BEAKER_debug=true
+    - env:
+      - DO=beaker
       - BEAKER_set=ubuntu_1804
+      - BEAKER_PUPPET_COLLECTION=puppet5
+      - BEAKER_debug=true
+    - env:
+      - DO=beaker
+      - BEAKER_set=ubuntu_1804
+      - BEAKER_PUPPET_COLLECTION=puppet6
+      - BEAKER_debug=true
     - stage: deploy
       script: true
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,27 +37,22 @@ jobs:
       - DO=beaker
       - BEAKER_set=ubuntu_1404
       - BEAKER_PUPPET_COLLECTION=puppet5
-      - BEAKER_debug=true
     - env:
       - DO=beaker
       - BEAKER_set=ubuntu_1604
       - BEAKER_PUPPET_COLLECTION=puppet5
-      - BEAKER_debug=true
     - env:
       - DO=beaker
       - BEAKER_set=ubuntu_1604
       - BEAKER_PUPPET_COLLECTION=puppet6
-      - BEAKER_debug=true
     - env:
       - DO=beaker
       - BEAKER_set=ubuntu_1804
       - BEAKER_PUPPET_COLLECTION=puppet5
-      - BEAKER_debug=true
     - env:
       - DO=beaker
       - BEAKER_set=ubuntu_1804
       - BEAKER_PUPPET_COLLECTION=puppet6
-      - BEAKER_debug=true
     - stage: deploy
       script: true
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,23 @@ jobs:
     - stage: acceptance
       env:
       - DO=beaker
-      - PUPPET='~> 4'
+      - BEAKER_PUPPET_COLLECTION=puppet5
       - BEAKER_set=ubuntu_1404
     - env:
       - DO=beaker
-      - PUPPET='~> 5'
+      - BEAKER_PUPPET_COLLECTION=puppet5
       - BEAKER_set=ubuntu_1604
     - env:
       - DO=beaker
-      - PUPPET='~> 5'
+      - BEAKER_PUPPET_COLLECTION=puppet6
+      - BEAKER_set=ubuntu_1604
+    - env:
+      - DO=beaker
+      - BEAKER_PUPPET_COLLECTION=puppet5
+      - BEAKER_set=ubuntu_1804
+    - env:
+      - DO=beaker
+      - BEAKER_PUPPET_COLLECTION=puppet6
       - BEAKER_set=ubuntu_1804
     - stage: deploy
       script: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Puppet 6 support.
+
+### Changed
+- Validation, Unit, and Acceptance stages now all include Puppet 6.
+- Run acceptance tests using new puppet and module install helpers.
 
 ## [0.7.0] - 2018-09-08
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 
 group :acceptance do
   gem 'beaker-docker'
-  gem 'beaker-puppet', '= 1.1.0'
+  gem 'beaker-puppet'
   gem 'beaker-rspec'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :documentation do
 end
 
 group :unit do
-  gem 'puppet', ENV.fetch('PUPPET', '~> 5')
+  gem 'puppet', ENV.fetch('PUPPET', '>= 4.4')
   gem 'puppetlabs_spec_helper'
   gem 'rspec-puppet-facts'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,10 @@ end
 
 group :acceptance do
   gem 'beaker-docker'
-  gem 'beaker-puppet'
-  gem 'beaker-rspec'
   gem 'beaker-module_install_helper'
+  gem 'beaker-puppet'
   gem 'beaker-puppet_install_helper'
+  gem 'beaker-rspec'
 end
 
 group :documentation do

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ group :acceptance do
   gem 'beaker-docker'
   gem 'beaker-puppet'
   gem 'beaker-rspec'
+  gem 'beaker-module_install_helper'
+  gem 'beaker-puppet_install_helper'
 end
 
 group :documentation do

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.4.0 < 6.0.0"
+      "version_requirement": ">= 4.4.0 < 7.0.0"
     }
   ],
   "pdk-version": "1.6.1",

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,19 +1,17 @@
 # frozen_string_literal: true
 
-require 'beaker-puppet'
 require 'beaker-rspec'
+require 'beaker-puppet'
+require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
 
-install_puppet_from_gem_on(hosts, version: ENV.fetch('PUPPET', '~> 5.0'))
+run_puppet_install_helper
+install_module_on(hosts)
+install_module_dependencies_on(hosts)
 
 RSpec.configure do |c|
   c.color     = true
   c.formatter = :documentation
-  c.before :suite do
-    hosts.each do |host|
-      copy_root_module_to(host, module_name: 'cron', target_module_path: '/etc/puppetlabs/code/modules')
-      on host, puppet('module', 'install', 'puppetlabs-stdlib')
-    end
-  end
 end
 
 # This runs the supplied manifest twice on the host.


### PR DESCRIPTION
This PR adds Puppet 6 support. The changes only involve the testing suite - no code changes have been made.