### PR TITLE
Initial FreeBSD support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Preliminary FreeBSD support (no acceptance testing, ouch).
 
 ## [0.11.0] - 2024-08-01
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -1,78 +1,21 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
-
-def location_for(place_or_version, fake_version = nil)
-  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
-  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
-
-  if place_or_version && (git_url = place_or_version.match(git_url_regex))
-    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
-  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
-    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
-  else
-    [place_or_version, { require: false }]
-  end
-end
+source 'https://rubygems.org'
 
 group :development do
-  gem "json", '= 2.1.0',                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.5.1',                         require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "deep_merge", '~> 1.2.2',                  require: false
-  gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
-  gem "facterdb", '~> 1.26',                     require: false
-  gem "metadata-json-lint", '~> 4.0',            require: false
-  gem "rspec-puppet-facts", '~> 3.0',            require: false
-  gem "dependency_checker", '~> 1.0.0',          require: false
-  gem "parallel_tests", '= 3.12.1',              require: false
-  gem "pry", '~> 0.10',                          require: false
-  gem "simplecov-console", '~> 0.9',             require: false
-  gem "puppet-debugger", '~> 1.0',               require: false
-  gem "rubocop", '~> 1.50.0',                    require: false
-  gem "rubocop-performance", '= 1.16.0',         require: false
-  gem "rubocop-rspec", '= 2.19.0',               require: false
-  gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "rexml", '>= 3.0.0', '< 3.2.7',            require: false
+  gem 'puppet', ENV.fetch('PUPPET_GEM_VERSION', '>= 7.6.1')
+  gem 'puppet-lint'
+  gem 'metadata-json-lint'
+  gem 'rspec-puppet-facts'
+  gem 'rubocop-rspec'
 end
+
 group :development, :release_prep do
-  gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 7.0', require: false
+  gem 'puppet-strings'
+  gem 'puppetlabs_spec_helper'
 end
+
 group :system_tests do
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw]
-  gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "serverspec", '~> 2.41',     require: false
-end
-
-puppet_version = ENV['PUPPET_GEM_VERSION']
-facter_version = ENV['FACTER_GEM_VERSION']
-hiera_version = ENV['HIERA_GEM_VERSION']
-
-gems = {}
-
-gems['puppet'] = location_for(puppet_version)
-
-# If facter or hiera versions have been specified via the environment
-# variables
-
-gems['facter'] = location_for(facter_version) if facter_version
-gems['hiera'] = location_for(hiera_version) if hiera_version
-
-gems.each do |gem_name, gem_params|
-  gem gem_name, *gem_params
-end
-
-# Evaluate Gemfile.local and ~/.gemfile if they exist
-extra_gemfiles = [
-  "#{__FILE__}.local",
-  File.join(Dir.home, '.gemfile'),
-]
-
-extra_gemfiles.each do |gemfile|
-  if File.file?(gemfile) && File.readable?(gemfile)
-    eval(File.read(gemfile), binding)
-  end
+  gem 'puppet_litmus'
+  gem 'CFPropertyList'
+  gem 'serverspec'
 end
 # vim: syntax=ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,21 +1,78 @@
-source 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+
+def location_for(place_or_version, fake_version = nil)
+  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
+  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
+
+  if place_or_version && (git_url = place_or_version.match(git_url_regex))
+    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
+  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
+    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+  else
+    [place_or_version, { require: false }]
+  end
+end
 
 group :development do
-  gem 'puppet', ENV.fetch('PUPPET_GEM_VERSION', '>= 7.6.1')
-  gem 'puppet-lint'
-  gem 'metadata-json-lint'
-  gem 'rspec-puppet-facts'
-  gem 'rubocop-rspec'
+  gem "json", '= 2.1.0',                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                         require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "deep_merge", '~> 1.2.2',                  require: false
+  gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
+  gem "facterdb", '~> 1.26',                     require: false
+  gem "metadata-json-lint", '~> 4.0',            require: false
+  gem "rspec-puppet-facts", '~> 3.0',            require: false
+  gem "dependency_checker", '~> 1.0.0',          require: false
+  gem "parallel_tests", '= 3.12.1',              require: false
+  gem "pry", '~> 0.10',                          require: false
+  gem "simplecov-console", '~> 0.9',             require: false
+  gem "puppet-debugger", '~> 1.0',               require: false
+  gem "rubocop", '~> 1.50.0',                    require: false
+  gem "rubocop-performance", '= 1.16.0',         require: false
+  gem "rubocop-rspec", '= 2.19.0',               require: false
+  gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "rexml", '>= 3.0.0', '< 3.2.7',            require: false
 end
-
 group :development, :release_prep do
-  gem 'puppet-strings'
-  gem 'puppetlabs_spec_helper'
+  gem "puppet-strings", '~> 4.0',         require: false
+  gem "puppetlabs_spec_helper", '~> 7.0', require: false
+end
+group :system_tests do
+  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw]
+  gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "serverspec", '~> 2.41',     require: false
 end
 
-group :system_tests do
-  gem 'puppet_litmus'
-  gem 'CFPropertyList'
-  gem 'serverspec'
+puppet_version = ENV['PUPPET_GEM_VERSION']
+facter_version = ENV['FACTER_GEM_VERSION']
+hiera_version = ENV['HIERA_GEM_VERSION']
+
+gems = {}
+
+gems['puppet'] = location_for(puppet_version)
+
+# If facter or hiera versions have been specified via the environment
+# variables
+
+gems['facter'] = location_for(facter_version) if facter_version
+gems['hiera'] = location_for(hiera_version) if hiera_version
+
+gems.each do |gem_name, gem_params|
+  gem gem_name, *gem_params
+end
+
+# Evaluate Gemfile.local and ~/.gemfile if they exist
+extra_gemfiles = [
+  "#{__FILE__}.local",
+  File.join(Dir.home, '.gemfile'),
+]
+
+extra_gemfiles.each do |gemfile|
+  if File.file?(gemfile) && File.readable?(gemfile)
+    eval(File.read(gemfile), binding)
+  end
 end
 # vim: syntax=ruby

--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -1,0 +1,3 @@
+---
+cron::manage_package: false
+...

--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -1,3 +1,4 @@
 ---
+cron::root_group: wheel
 cron::manage_package: false
 ...

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,13 @@
+---
+version: 5
+
+defaults:
+  datadir: data
+  data_hash: yaml_data
+
+hierarchy:
+  - name: Operating System Family
+    path: '%{facts.os.family}.yaml'
+  - name: Common Configuration
+    path: common.yaml
+...

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,7 @@ class cron::config {
     default:
       force => true,
       owner => 'root',
-      group => 'root',
+      group => $cron::root_group,
       mode  => '0644';
     '/etc/cron.allow':
       ensure  => if (!$cron::allow_all_users and empty($cron::denied_users)) { file } else { absent },

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@
 #   }
 #
 # @param ensure Whether to enable or disable cron on the system.
+# @param manage_package Whether to manage cron package on the system.
 # @param package_version Custom `cron` package version.
 # @param allow_all_users Allow all users to manage crontab.
 # @param allowed_users List of users allowed to use `crontab(1)`. By default, only root can.
@@ -38,6 +39,7 @@ class cron (
   Enum[present, absent]  $ensure          = present,
 
   # cron::install
+  Boolean                $manage_package  = true,
   Pattern[/\A[^\n]+\z/]  $package_version = installed,
 
   # cron::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@
 # @param ensure Whether to enable or disable cron on the system.
 # @param manage_package Whether to manage cron package on the system.
 # @param package_version Custom `cron` package version.
+# @param root_group Name of the root group.
 # @param allow_all_users Allow all users to manage crontab.
 # @param allowed_users List of users allowed to use `crontab(1)`. By default, only root can.
 # @param denied_users List of users specifically denied to use `crontab(1)`.
@@ -43,6 +44,7 @@ class cron (
   Pattern[/\A[^\n]+\z/]  $package_version = installed,
 
   # cron::config
+  Pattern[/\A[^\n]+\z/]  $root_group      = 'root',
   Boolean                $allow_all_users = false,
   Array[Cron::User]      $allowed_users   = [],
   Array[Cron::User]      $denied_users    = [],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,7 +2,9 @@
 #
 # @api private
 class cron::install {
-  package { 'cron':
-    ensure => $cron::package_version,
+  if $cron::manage_package {
+    package { 'cron':
+      ensure => $cron::package_version,
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,7 @@
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
+        "13",
         "14"
       ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,12 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "14"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",

--- a/spec/classes/cron_spec.rb
+++ b/spec/classes/cron_spec.rb
@@ -14,7 +14,13 @@ describe 'cron' do
     it { is_expected.to contain_class('cron::service') }
 
     describe 'cron::install' do
-      it { is_expected.to contain_package('cron').with_ensure(:installed) }
+      on_supported_os.each do |os_name, facts|
+        context "on #{os_name}" do
+          let(:facts) { facts }
+
+          it { is_expected.to contain_package('cron').with_ensure(:installed) }
+        end
+      end
     end
 
     describe 'cron::config' do


### PR DESCRIPTION
## Summary
Add FreeBSD support.

## Additional Context
The main difference between Ubuntu is that `cron` package does not exist as it is part of the base system so ability to not manage package is required.

## Related Issues (if any)
Acceptance testing would be great on non-docker OSes, but I'm still trying to fight Litmus on that one.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)